### PR TITLE
fix: index out of bounds when running script

### DIFF
--- a/chatgpt_to_sqlite/utils.py
+++ b/chatgpt_to_sqlite/utils.py
@@ -16,7 +16,7 @@ def concatenate_rows(message: dict, chat_id: str) -> Optional[dict]:
     # sender (user, assistant, and system)
     sender = message["author"]["role"] if message["author"] else "unknown"
 
-    if "parts" not in message["content"]:
+    if "parts" not in message["content"] or not message["content"]["parts"]:
         return None
 
     metadata = message.get("metadata", {})


### PR DESCRIPTION
Ran the script - 
Found index out of bound.
```
    text = message["content"]["parts"][0]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```
Possibly parts is empty.

Re ran after fix.
Observed that conversations and messages have loaded.

Todo - Should log and verify what message is when parts is empty.